### PR TITLE
fix: Intel Arc GPU (XPU) サポートを追加 (#2)

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,7 +23,13 @@ st.set_page_config(
 @st.cache_resource
 def load_whisper_model(model_name):
     """Whisperモデルをロードする（キャッシュ使用）"""
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    # CUDA優先、なければXPU、どちらもなければCPU
+    if torch.cuda.is_available():
+        device = "cuda"
+    elif hasattr(torch, 'xpu') and torch.xpu.is_available():
+        device = "xpu"
+    else:
+        device = "cpu"
     return whisper.load_model(model_name, device=device)
 
 def check_ffmpeg():
@@ -71,7 +77,12 @@ def main():
     )
     
     # デバイス情報表示
-    device = "GPU (CUDA)" if torch.cuda.is_available() else "CPU"
+    if torch.cuda.is_available():
+        device = "GPU (CUDA)"
+    elif hasattr(torch, 'xpu') and torch.xpu.is_available():
+        device = "GPU (XPU)"
+    else:
+        device = "CPU"
     st.sidebar.info(f"使用デバイス: {device}")
     
     if device == "CPU":

--- a/test_device_selection.py
+++ b/test_device_selection.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+デバイス選択ロジックのテストスクリプト
+CPU環境での動作確認用
+"""
+
+import torch
+
+def test_device_selection():
+    """デバイス選択ロジックをテストする"""
+    print("=" * 50)
+    print("デバイス選択ロジックのテスト")
+    print("=" * 50)
+    
+    # CUDAの確認
+    cuda_available = torch.cuda.is_available()
+    print(f"CUDA available: {cuda_available}")
+    
+    # XPUの確認
+    xpu_available = False
+    if hasattr(torch, 'xpu'):
+        try:
+            xpu_available = torch.xpu.is_available()
+            print(f"XPU available: {xpu_available}")
+        except AttributeError:
+            print("XPU module exists but is_available() is not available")
+    else:
+        print("XPU module not found (this is normal if Intel Arc GPU is not installed)")
+    
+    # デバイス選択ロジックのテスト（app.pyと同じロジック）
+    if torch.cuda.is_available():
+        device = "cuda"
+    elif hasattr(torch, 'xpu') and torch.xpu.is_available():
+        device = "xpu"
+    else:
+        device = "cpu"
+    
+    print(f"\n選択されたデバイス: {device}")
+    
+    # 期待される動作の確認
+    print("\n" + "=" * 50)
+    print("期待される動作:")
+    if cuda_available:
+        print("✅ CUDAが利用可能 → 'cuda'が選択される")
+    elif xpu_available:
+        print("✅ XPUが利用可能 → 'xpu'が選択される")
+    else:
+        print("✅ CUDAもXPUも利用不可 → 'cpu'が選択される（正常）")
+    print("=" * 50)
+    
+    return device
+
+if __name__ == "__main__":
+    test_device_selection()
+

--- a/transcribe.py
+++ b/transcribe.py
@@ -46,8 +46,13 @@ def transcribe_audio(file_path, model_name="base", language=None):
     print(f"モデル '{model_name}' をロード中...")
     start_time = time.time()
     
-    # GPUが利用可能かチェック
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    # GPUが利用可能かチェック（CUDA優先、なければXPU、どちらもなければCPU）
+    if torch.cuda.is_available():
+        device = "cuda"
+    elif hasattr(torch, 'xpu') and torch.xpu.is_available():
+        device = "xpu"
+    else:
+        device = "cpu"
     print(f"デバイス: {device}")
     
     # モデルをロード


### PR DESCRIPTION
- CUDAと並行してXPUデバイス検出を追加
- 既存のCUDAユーザーとの互換性を維持（CUDA優先）
- XPUモジュールが存在しない環境でもエラーにならないようhasattrチェックを追加
- app.pyとtranscribe.pyのデバイス選択ロジックを更新
- デバイス選択検証用のテストスクリプトを追加

この変更により、Intel Arc GPUユーザーがGPUアクセラレーションを利用できるようになります。 既存のCUDAユーザーへの影響はありません。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Intel XPU support alongside CUDA for Whisper device selection, prioritizing `cuda` → `xpu` → `cpu` with `hasattr(torch, 'xpu')` checks to avoid attribute errors.
> 
> - Update device selection and display in `app.py` (`load_whisper_model` and sidebar device info)
> - Update `transcribe.py` to load models on `xpu` when available (fallbacks preserved)
> - Add `test_device_selection.py` to print availability and validate the same selection logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99705a05cd3c98a8e41b421c1fd0a51334e67247. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->