### PR TITLE
refactor: FFmpeg確認処理をsubprocessモジュールに変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,13 @@ venv.bak/
 .coverage
 htmlcov/
 
+# テストファイル
+test_device_selection.py
+test_ffmpeg_check.py
+
+# サンプル・例
+examples/
+
 # ログとデータファイル
 *.log
 *.csv

--- a/app.py
+++ b/app.py
@@ -7,6 +7,8 @@ import os
 import sys
 import time
 import tempfile
+import subprocess
+import platform
 import whisper
 import torch
 import streamlit as st
@@ -33,9 +35,21 @@ def load_whisper_model(model_name):
     return whisper.load_model(model_name, device=device)
 
 def check_ffmpeg():
-    """FFmpegがインストールされているか確認"""
-    if os.system("ffmpeg -version > /dev/null 2>&1") != 0:
-        st.error("⚠️ FFmpegがインストールされていません。https://ffmpeg.org/download.html からダウンロードしてください。")
+    """FFmpegがインストールされているか確認（subprocessを使用、OS非依存）"""
+    try:
+        subprocess.run(
+            ["ffmpeg", "-version"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        error_msg = "⚠️ FFmpegがインストールされていません。"
+        if platform.system() == "Windows":
+            error_msg += "\nhttps://ffmpeg.org/download.html からダウンロードし、PATHに追加してください。"
+        else:
+            error_msg += "\nhttps://ffmpeg.org/download.html からダウンロードしてください。"
+        st.error(error_msg)
         st.stop()
 
 def get_available_models():

--- a/transcribe.py
+++ b/transcribe.py
@@ -5,6 +5,8 @@ Whisperを使用した音声文字起こしスクリプト
 
 import os
 import argparse
+import subprocess
+import platform
 import whisper
 import torch
 import time
@@ -12,10 +14,21 @@ import sys
 from datetime import datetime
 
 def check_ffmpeg():
-    """FFmpegがインストールされているか確認"""
-    if os.system("ffmpeg -version > /dev/null 2>&1") != 0:
-        print("エラー: FFmpegがインストールされていません。")
-        print("https://ffmpeg.org/download.html からダウンロードし、インストールしてください。")
+    """FFmpegがインストールされているか確認（subprocessを使用、OS非依存）"""
+    try:
+        subprocess.run(
+            ["ffmpeg", "-version"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        error_msg = "エラー: FFmpegがインストールされていません。"
+        if platform.system() == "Windows":
+            error_msg += "\nhttps://ffmpeg.org/download.html からダウンロードし、PATHに追加してください。"
+        else:
+            error_msg += "\nhttps://ffmpeg.org/download.html からダウンロードしてください。"
+        print(error_msg)
         sys.exit(1)
 
 def get_available_models():


### PR DESCRIPTION
- os.systemと/dev/nullの使用をやめ、subprocessを使用
- クロスプラットフォーム対応を実現（Windows/macOS/Linux）
- platformモジュールでOS判定し、適切なエラーメッセージを表示
- .gitignoreにテストファイルとexamples/を追加

PR #1の実装（os.system使用）から、より安全なsubprocess実装に改善

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes FFmpeg detection and improves cross-platform behavior.
> 
> - Replace `os.system`-based FFmpeg checks with `subprocess.run` in `app.py` and `transcribe.py`, adding platform-aware error messages and terminating via `st.stop()`/`sys.exit(1)`
> - Add imports for `subprocess` and `platform`
> - Update `.gitignore` to ignore test files (`test_device_selection.py`, `test_ffmpeg_check.py`) and `examples/`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f401acbd87cf6c04f5c3b225986d8e54a7f9b3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->